### PR TITLE
fix: encode Proofpoint campaign IDs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Proofpoint TAP
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Proofpoint TAP
 
-Publisher: Splunk Community \
-Connector Version: 2.1.1 \
-Product Vendor: Proofpoint \
-Product Name: Targeted Attack Protection \
+Publisher: Splunk Community <br>
+Connector Version: 2.1.1 <br>
+Product Vendor: Proofpoint <br>
+Product Name: Targeted Attack Protection <br>
 Minimum Product Version: 5.5.0
 
 This App integrates with Proofpoint to implement ingestion and investigative actions
@@ -24,19 +24,19 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - This action runs a quick query on the server to check the connection and credentials \
-[on poll](#action-on-poll) - Callback action for the On Poll ingest functionality \
-[get campaign data](#action-get-campaign-data) - Fetch detailed information for a given campaign (deprecated) \
-[get campaign](#action-get-campaign) - Fetch detailed information for a given campaign \
-[get forensic data](#action-get-forensic-data) - Fetch forensic information for a given threat or campaign (deprecated) \
-[get forensic](#action-get-forensic) - Fetch forensic information for a given threat or campaign \
+[test connectivity](#action-test-connectivity) - This action runs a quick query on the server to check the connection and credentials <br>
+[on poll](#action-on-poll) - Callback action for the On Poll ingest functionality <br>
+[get campaign data](#action-get-campaign-data) - Fetch detailed information for a given campaign (deprecated) <br>
+[get campaign](#action-get-campaign) - Fetch detailed information for a given campaign <br>
+[get forensic data](#action-get-forensic-data) - Fetch forensic information for a given threat or campaign (deprecated) <br>
+[get forensic](#action-get-forensic) - Fetch forensic information for a given threat or campaign <br>
 [decode url](#action-decode-url) - Decode Proofpoint rewritten URL(s)
 
 ## action: 'test connectivity'
 
 This action runs a quick query on the server to check the connection and credentials
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -51,7 +51,7 @@ No Output
 
 Callback action for the On Poll ingest functionality
 
-Type: **ingest** \
+Type: **ingest** <br>
 Read only: **True**
 
 For the 'start_time' parameter, the default is the past 10 days and for the 'end_time' parameter, the default is now.
@@ -74,7 +74,7 @@ No Output
 
 Fetch detailed information for a given campaign (deprecated)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action is deprecated due to action name change. Please use <b>get campaign</b> instead.
@@ -116,7 +116,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Fetch detailed information for a given campaign
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -156,7 +156,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Fetch forensic information for a given threat or campaign (deprecated)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action is deprecated due to action name change. Please use <b>get forensic</b> instead.
@@ -221,7 +221,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Fetch forensic information for a given threat or campaign
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -284,7 +284,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Decode Proofpoint rewritten URL(s)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -315,7 +315,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/proofpoint.json
+++ b/proofpoint.json
@@ -20,7 +20,7 @@
     "min_phantom_version": "5.5.0",
     "logo": "logo_proofpoint.svg",
     "logo_dark": "logo_proofpoint_dark.svg",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "fips_compliant": false,
     "configuration": {
         "username": {
@@ -971,5 +971,11 @@
             ],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/proofpoint_connector.py
+++ b/proofpoint_connector.py
@@ -15,6 +15,7 @@
 import json
 import sys
 from datetime import datetime, timedelta
+from urllib.parse import quote
 
 import phantom.app as phantom
 import requests
@@ -441,7 +442,7 @@ class ProofpointConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(param))
         campaign_id = param.get("campaign_id")
 
-        campaign_url = PP_API_PATH_CAMPAIGN.format(campaign_id)
+        campaign_url = PP_API_PATH_CAMPAIGN.format(quote(str(campaign_id), safe=""))
 
         params = {"format": "json"}
 

--- a/proofpoint_connector.py
+++ b/proofpoint_connector.py
@@ -1,6 +1,6 @@
 # File: proofpoint_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/proofpoint_consts.py
+++ b/proofpoint_consts.py
@@ -1,6 +1,6 @@
 # File: proofpoint_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: update connector development hooks.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: update connector development hooks.
+* Encode campaign IDs as a single URL path segment before calling the Proofpoint TAP campaign endpoint.


### PR DESCRIPTION
Written by Codex for ESPM-5228.

## Summary

- percent-encode caller-supplied campaign IDs as one URL path segment
- prevent slash, dot-segment, and query delimiters from escaping the Proofpoint TAP campaign endpoint
- preserve the read-only classification of both campaign action aliases

## Tracking

- PAPP: PAPP-38021
- PSAAS: PSAAS-31160
- Provenance: VULN-93885 / FS-2010

## Source-backed validation

RFC 3986 defines slash as a path-segment delimiter and question mark as the query delimiter. Encoding the complete campaign ID with Python quote and safe="" preserves it as data within one segment: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.3

The attached ticket patch was independently validated and adopted at the shared _get_campaign_details sink, which covers both get campaign and deprecated get campaign data without changing their action classification.

## Breaking changes

None. Valid campaign IDs continue to address the same campaign resource.

## Verification

- Docker dependency packaging completed its required generated-file cycle and passed on rerun
- repository-wide lint, formatting, app-linter, semgrep, secret, docs, copyright, notice, release-note, and static-test hooks passed
- python3 -m py_compile proofpoint_connector.py proofpoint_consts.py
- focused traversal, query-delimiter, slash, Unicode, and ordinary-ID scenarios passed
- focused manifest checks confirmed both campaign actions remain read_only: true
- both commits have valid GPG signatures
- integration testing deferred to CI / SOAR test infrastructure
